### PR TITLE
Fix to work more like GNU realpath for relative PATHs.

### DIFF
--- a/realpath
+++ b/realpath
@@ -125,7 +125,7 @@ if [ $# -gt 0 ]; then
 			if [ $? -ne 0 ]; then
 				success=false
 			fi
-			echo "$path"
+			echo "$(dirname "$path"/.)"
 			shift
 		fi
 	done


### PR DESCRIPTION
For instance the current behavior that is different with Ohlah realpath:

   Current Ohloh realpath:

```
  jsantiago@jlsws:~/test99/realpath$ pwd
     /home/jsantiago/test99/realpath

  jsantiago@jlsws:~/test99/realpath$ ./realpath .
     /data/home/jsantiago/test99/realpath/

  jsantiago@jlsws:~/test99/realpath$ ./realpath ../
     /data/home/jsantiago/test99/

  jsantiago@jlsws:~/test99/realpath$ ./realpath ../realpath/.
     /data/home/jsantiago/test99/realpath/
```

   GNU realpath (Notice there is no / at the end)

```
  jsantiago@jlsws:~/test99/realpath$ pwd
     /home/jsantiago/test99/realpath

  jsantiago@jlsws:~/test99/realpath$ realpath .
     /data/home/jsantiago/test99/realpath

  jsantiago@jlsws:~/test99/realpath$ realpath ../
     /data/home/jsantiago/test99

  jsantiago@jlsws:~/test99/realpath$ realpath ../realpath/.
     /data/home/jsantiago/test99/realpath
```

   After my change Ohloh realpath:

```
  jsantiago@jlsws:~/test99/realpath$ pwd
     /home/jsantiago/test99/realpath

  jsantiago@jlsws:~/test99/realpath$ ./realpath .
     /data/home/jsantiago/test99/realpath

  jsantiago@jlsws:~/test99/realpath$ ./realpath ../
     /data/home/jsantiago/test99

  jsantiago@jlsws:~/test99/realpath$ ./realpath ../realpath/.
     /data/home/jsantiago/test99/realpath
```

GNU raelpath I am testing against:

   jsantiago@jlsws:~/test99/realpath$ pwd
      /home/jsantiago/test99/realpath

   jsantiago@jlsws:~/test99/realpath$ which realpath
      /usr/bin/realpath

   jsantiago@jlsws:~/test99/realpath$ realpath --version
      realpath (GNU coreutils) 8.15
      Copyright (C) 2012 Free Software Foundation, Inc.
      License GPLv3+: GNU GPL version 3 or later http://gnu.org/licenses/gpl.html.
      This is free software: you are free to change and redistribute it.
      There is NO WARRANTY, to the extent permitted by law.

```
  Written by Pádraig Brady.
```
